### PR TITLE
Avoid double fade

### DIFF
--- a/src/TipProvider.js
+++ b/src/TipProvider.js
@@ -437,7 +437,6 @@ export default class TipProvider extends Component {
 
         return (
             <Modal
-                animationType="fade"
                 visible
                 onRequestClose={this.closeTip}
                 transparent


### PR DESCRIPTION
Currently, when pressing anywhere on the screen to dismiss the tip, the tip fades twice. Removing the fade on the modal itself fixes that, since there is already a fade animation in the `animateOut` function.